### PR TITLE
[FIX] permita que o helm faça a comparação de versão do kubernetes

### DIFF
--- a/charts/odoo-doodba/templates/ingress.yaml
+++ b/charts/odoo-doodba/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
-{{/*{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
-{{- end }}*/}}
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
Remova o comentário (ver https://helm.sh/docs/chart_best_practices/templates/ na sessão Template Comments),
permitindo assim que a versão do kubernetes seja usada para configurar a versão de api correta para ingress
