### PR TITLE
[CHG] Desative o uso de envs via montagem de configmap

### DIFF
--- a/charts/odoo-doodba/Chart.yaml
+++ b/charts/odoo-doodba/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
   name: Paul Catinean
   url: http://pledra.com
 name: odoo-doodba
-version: 2.0.5
+version: 2.0.6

--- a/charts/odoo-doodba/templates/deployment.yaml
+++ b/charts/odoo-doodba/templates/deployment.yaml
@@ -125,9 +125,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{/*
           - name: odoo-config
             mountPath: "/opt/odoo/custom/conf.d"
             readOnly: true
+          */}}
           - name: odoo
             mountPath: /var/lib/odoo
             {{ if .Values.persistence.subPath }}


### PR DESCRIPTION
    Atualmente, persistence: true
    implica em montar dois volumes no pod, um em
    /var/lib/odoo, e um em /opt/odoo/custom/conf.d
    Esse segundo é um configmap montado como readonly, e
    que disponibilizaria uma segunda fonte de variáveis de
    ambiente para a aplicação.
    Desative-o, de forma que persistence: true implique somente
    em um PVC/PV montado em /var/lib/odoo para o container
