### PR TITLE
[ADD] novo Chart: simple-odoo

### DIFF
--- a/charts/simple-odoo/.helmignore
+++ b/charts/simple-odoo/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/simple-odoo/Chart.yaml
+++ b/charts/simple-odoo/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: simple-odoo
+description: A Helm chart for odoo deploy (odoo only)
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/charts/simple-odoo/templates/_helpers.tpl
+++ b/charts/simple-odoo/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "odoo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "odoo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "odoo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "odoo.labels" -}}
+helm.sh/chart: {{ include "odoo.chart" . }}
+{{ include "odoo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "odoo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "odoo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "odoo.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "odoo.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/simple-odoo/templates/custom-startup-script.yaml
+++ b/charts/simple-odoo/templates/custom-startup-script.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.customStartScript }}
+{{- if .Values.customStartScript.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-custom-start-script
+  annotations:
+    checksum/custom-init-script: "{{ .Values.customStartScript.script | toYaml | sha256sum }}"
+    checksum/environment: "{{ .Values.config | toYaml | sha256sum }}"
+data:
+  custom-init-script: {{ .Values.customStartScript.script | toYaml | indent 1 }}
+{{- end }}
+{{- end }}

--- a/charts/simple-odoo/templates/deployment.yaml
+++ b/charts/simple-odoo/templates/deployment.yaml
@@ -1,0 +1,112 @@
+{{- $validPorts := false -}}
+{{- range .Values.ingress.ports }}
+  {{- if and .name .number }}
+    {{- $validPorts = true -}}
+  {{- end }}
+{{- end }}
+
+{{- if not $validPorts }}
+  {{ fail "At least one port must have valid 'name' and 'number' fields" }}
+{{- end }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "odoo.fullname" . }}
+  annotations:
+    {{- if .Values.customStartScript.enabled }}
+    checksum/custom-init-script: "{{ .Values.customStartScript.script | toYaml | sha256sum }}"
+    {{- end }}
+    checksum/environment: "{{ .Values.config | toYaml | sha256sum }}"
+{{ include "odoo.labels" . | indent 4 }}
+spec:
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "odoo.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "odoo.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        {{- if .Values.customStartScript.enabled }}
+        checksum/custom-init-script: "{{ .Values.customStartScript.script | toYaml | sha256sum }}"
+        {{- end }}
+        checksum/environment: "{{ .Values.config | toYaml | sha256sum }}"
+    spec:
+      imagePullSecrets:
+      - name: {{ printf "%s-%s" (sha256sum (printf "%s%s" .Values.imagePullSecret.user .Values.imagePullSecret.password) | substr 0 16) .Release.Name }}
+    {{- if .Values.persistence.enabled }}
+    {{- if .Values.persistence.initVolume }}
+      initContainers:
+        - name: volume-init
+          image: busybox
+          command: ['sh', '-c', 'chown 1000:1000 -R /odoo']
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
+            limits:
+              cpu: "100m"
+              memory: "200Mi"
+          volumeMounts:
+          - name: odoo
+            mountPath: /odoo
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "odoo.fullname" . }}-container
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.customStartScript.enabled }}
+          command:
+          - {{ .Values.customStartScript.command }}
+          - /init-script-path/custom-init-script
+          {{- end }}
+          ports:
+          {{- range $.Values.ingress.ports }}
+          - containerPort: {{ .number }}
+            name: {{ .name }}
+          {{- end }}
+          envFrom:
+          - secretRef:
+              name: {{ include "odoo.fullname" . }}-environment
+          volumeMounts:
+          {{ if .Values.persistence.enabled }}
+          - name: odoo
+            mountPath: /var/lib/odoo
+          {{ end }}
+          {{- if .Values.customStartScript.enabled }}
+          - name: init-script-volume
+            mountPath: /init-script-path
+          {{ end }}
+      volumes:
+      {{ if .Values.persistence.enabled }}
+      - name: odoo
+        persistentVolumeClaim:
+          claimName: {{ include "odoo.fullname" . }}-pvc
+      {{ end }}
+      {{- if .Values.customStartScript.enabled }}
+      - name: init-script-volume
+        configMap: 
+          name: {{ .Release.Name }}-custom-start-script
+      {{ end }}
+      {{- if .Values.nodeSelector }}
+      {{- if .Values.nodeSelector.enabled }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.nodeSelector.labelname }}
+                operator: In
+                values:
+                - "{{ .Values.nodeSelector.labelvalue }}"
+      {{- end }}
+      {{- end }}

--- a/charts/simple-odoo/templates/environment.yaml
+++ b/charts/simple-odoo/templates/environment.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "odoo.fullname" . }}-environment
+  annotations:
+    {{- if .Values.customStartScript.enabled }}
+    checksum/custom-init-script: "{{ .Values.customStartScript.script | toYaml | sha256sum }}"
+    {{- end }}
+    checksum/environment: "{{ .Values.config | toYaml | sha256sum }}"
+{{ include "odoo.labels" . | indent 4 }}
+type: Opaque
+data:
+  {{- if .Values.config }}
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/simple-odoo/templates/image-secret.yaml
+++ b/charts/simple-odoo/templates/image-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" (sha256sum (printf "%s%s" .Values.imagePullSecret.user .Values.imagePullSecret.password) | substr 0 16) .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "odoo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ printf "{\"auths\": {\"%s\": {\"username\": \"%s\", \"password\": \"%s\", \"auth\": \"%s\"}}}" .Values.imagePullSecret.server .Values.imagePullSecret.user .Values.imagePullSecret.password (printf "%s:%s" .Values.imagePullSecret.user .Values.imagePullSecret.password | b64enc ) | b64enc }}
+

--- a/charts/simple-odoo/templates/ingress.yaml
+++ b/charts/simple-odoo/templates/ingress.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.ingress.enabled }}
+  {{- $validPorts := false -}}
+  {{- $validDomains := false -}}
+
+  {{- range .Values.ingress.ports }}
+    {{- if and .path .name .number }}
+      {{- $validPorts = true -}}
+    {{- end }}
+  {{- end }}
+
+  {{- range .Values.ingress.domains }}
+    {{- if .url }}
+      {{- $validDomains = true -}}
+    {{- end }}
+  {{- end }}
+
+  {{- if not $validPorts }}
+    {{ fail "At least one port must have valid 'path', 'name', and 'number' fields" }}
+  {{- end }}
+
+  {{- if not $validDomains }}
+    {{ fail "At least one domain must have a valid 'url'" }}
+  {{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  annotations:
+    checksum/ingress: "{{ .Values.ingress | toYaml | sha256sum }}"
+  {{ if .Values.ingress.recommendedNginxSettings }}
+    nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+    nginx.ingress.kubernetes.io/proxy-body-size: '2000m'
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '15'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '1500'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '1500'
+    nginx.ingress.kubernetes.io/gzip-types: "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/xml text/plain text/x-component text/less"
+  {{ end }}
+  {{ if .Values.ingress.wwwNginxRedirect }}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+  {{ end }}
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  rules:
+  {{- range .Values.ingress.domains }}
+  - host: {{ .url| quote }}
+    http:
+      paths:
+      {{- range $.Values.ingress.ports }}
+      - backend:
+          service:
+            name: {{ $.Release.Name }}-service
+            port:
+              number: {{ .number }}
+        path: {{ .path | quote }}
+        pathType: ImplementationSpecific
+     {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+     {{- range .Values.ingress.domains }}
+    - hosts:
+        - {{ .url }}
+      secretName: {{ default ( replace "." "-" (printf "%s--%s" .url "tls-secret")) .secretName }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/simple-odoo/templates/pvc.yaml
+++ b/charts/simple-odoo/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "odoo.fullname" . }}-pvc
+  labels:
+{{ include "odoo.labels" . | indent 4 }}
+{{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{ end }}

--- a/charts/simple-odoo/templates/service.yaml
+++ b/charts/simple-odoo/templates/service.yaml
@@ -1,0 +1,32 @@
+{{- $validPorts := false -}}
+{{- range .Values.ingress.ports }}
+  {{- if and .name .number }}
+    {{- $validPorts = true -}}
+  {{- end }}
+{{- end }}
+
+{{- if not $validPorts }}
+  {{ fail "At least one port must have valid 'name' and 'number' fields" }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-service
+  annotations:
+    checksum/service: "{{- $concat := "" -}}
+                        {{- range .Values.ingress.ports -}}
+                        {{- $concat = printf "%s%s=%s" $concat .name .number -}}
+                        {{- end -}}
+                        {{- $concat | sha256sum }}"
+spec:
+  type: ClusterIP
+  ports:
+    {{- range .Values.ingress.ports }}
+    - name: {{ .name }}
+      port: {{ .number }}
+      targetPort: {{ .number }}
+    {{- end }}
+  selector:
+    app: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "odoo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/simple-odoo/values.yaml
+++ b/charts/simple-odoo/values.yaml
@@ -1,0 +1,82 @@
+replicaCount: 1
+
+image:
+  repository: registry.chart.example/odoo/odoo
+  tag: "latest"
+  imagePullPolicy: IfNotPresent
+
+updateStrategy:
+  type: Recreate
+
+nodeSelector:
+  enabled: false
+  labelname: "kubernetes.io/hostname"
+  labelvalue: "node-hostname"
+
+imagePullSecret:
+  server: "registry.chart.example"
+  user: "user-chart-example"
+  password: "3e9aafc8-429d-4450-a99f-1cba4adcbeac"
+
+### environment
+config:
+  ENV_0: "value_0"
+  ENV_1: "value_1"
+  ENV_2: "value_2"
+  ENV_3: "value_3"
+  ENV_4: "value_4"
+  ENV_5: "value_5"
+  ENV_6: "value_6"
+  ENV_7: "value_7"
+  ENV_8: "value_8"
+  ENV_9: "value_9"
+
+  
+ingress:
+  enabled: true
+  className: "nginx"
+  wwwNginxRedirect: true
+  recommendedNginxSettings: true
+  tls:
+    enabled: true
+  domains:
+  - url: "domain1.com"
+    secretName: domain1-cert-tls-secret
+  - url: "domain2.com"
+    #secretName: null = auto-generate-name
+  - url: "domain3.com"
+    secretName: domain3-cert-tls-secret
+
+  ports:
+  - path: "/"
+    name: "web"
+    number: 8069
+  - path: "/websocket"
+    name: "secondary"
+    number: 8072
+  #- path: "/api"
+  #  name: "apiexpose"
+  #  number: 4000
+  ingressAnnotations:
+    {}
+
+persistence:
+  enabled: false
+  initVolume: false
+  storageClass: "local-path" ### k3s -> https://github.com/rancher/local-path-provisioner
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+customStartScript:
+  enabled: false
+  command: /bin/sh  ### or /bin/bash ; or /usr/local/bin/python ...
+  script: |
+    #!/bin/sh
+    set -x
+    command_1 &&
+    command_2 &&
+    command_3 &&
+    command_4 &&
+    command_5 &&
+    command_6 &&
+    /default/image/entrypoint || echo 'custom entrypoint script not work, sleeping ...' ;  sleep infinity


### PR DESCRIPTION
    Visa casos de uso mais flexiveis para o odoo em si;
    porém, abre mão (propositalmente) de suportar toda a infraestrutura
    ao redor (postgres e redis por exempo).

    [template] Abandona o suporte a versões desatualizadas do Kubernetes.

    [template] Uso de checksum nas annotations para atrelar deployment, environment e o script
    customizado (mais sobre esse último a seguir).

    [template] Validação de campos, impedindo que campos necessários
    sejam nulos.

    [values] Campo simplificado para uso de nodeLabel, que permite 'prender'
    a execução a nós especificos do cluster (por exemplo, para clusters
    de performance heterogênea).

    [values] Suporte a criação ao secret para image pull.
    O nome do secret é gerado usando o hash da concatenação de seus
    dados, de forma que renovar a credencial gera um novo secret.

    [values] Todas as variáveis de ambiente são obtidas a partir de um único
    campo.

    [values] Suporte o uso de multiplas urls para a mesma instancia, permitindo o
    fornecimento de secret tls por url; quando o nome do secret não é
    determinado, ele é gerado (o alvo aqui é integração com cert-manager/letsencrypt).

    [values] Suporte à customização simplificada de número e caminho de porta,
    permitindo o uso tanto com /longpolling quanto /websocket, e
    inclusive a (e/a)dição de (mais) portas no futuro.

    [values] O suporte a storage-class agnóstico é mantido; mas agora um padrão é
    definido, a saber, local-path-provisioner, a storage-class padrão do k3s.
    (https://docs.k3s.io/storage) (https://github.com/rancher/local-path-provisioner)

    [values] Suporta a inserção de script de execução antecipada, para cenários
    onde comandos são necessários antes do odoo.
    Isso deve ser usado com cuidado, pois é possível subverter totalmente o container,
    fazendo-o executar uma carga de trabalho diversa; inclusive obtendo
    código remotamente (curl | python por exemplo).
    Como é suposto que o acesso a edição do values.yaml ou mesmo do
    configmap diretamente no cluster alvo é controlado, foi considerado
    que o benefício supera o risco.