### PR TITLE
[CHG] simple-odoo: suporte a inclusão dinâmica de manifestos (templat…

### DIFF
--- a/charts/simple-odoo/Chart.yaml
+++ b/charts/simple-odoo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: simple-odoo
 description: A Helm chart for odoo deploy (odoo only)
 type: application
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.0.2
+appVersion: "1.0.2"

--- a/charts/simple-odoo/templates/extra-manifests.yaml
+++ b/charts/simple-odoo/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraK8sYaml }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/simple-odoo/values.yaml
+++ b/charts/simple-odoo/values.yaml
@@ -89,3 +89,7 @@ customStartScript:
     command_5 &&
     command_6 &&
     /default/image/entrypoint || echo 'custom entrypoint script not work, sleeping ...' ;  sleep infinity
+
+
+## full kubernetes yaml (support expand values)
+extraK8sYaml: {}


### PR DESCRIPTION
…es) adicionais

    use extraK8sYaml para adicionar templates que forem necessários

    A expansão de valores é suportada, então pode-se fazer algo como:

    ```values.yaml
    ....

    extraEnvs:
      KEY: "value"

    extraK8sYaml:
      - | apiVersion: v1 kind: Secret metadata: name: {{ include "odoo.fullname" . }}-extra-env annotations: checksum/extrak8syaml: "{{ .Values.extraK8sYaml | toYaml | sha256sum }}" checksum/extraenvs: "{{ .Values.extraEnvs | toYaml | sha256sum }}" {{ include "odoo.labels" . | indent 4 }} type: Opaque data: {{- $extraEnvs := .Values.extraEnvs | required "extraEnvs must be defined in values.yaml" }} {{- if .Values.extraEnvs }} {{- range $key, $value := .Values.extraEnvs }} {{ $key }}: {{ $value | b64enc | quote }} {{- end }} {{- end }}
      - | apiVersion: v1 kind: Pod metadata: name: extra-pod annotations: checksum/extrak8syaml: "{{ .Values.extraK8sYaml | toYaml | sha256sum }}" checksum/extraenvs: "{{ .Values.extraEnvs | toYaml | sha256sum }}" spec: containers: - name: extra-container image: extra-image envFrom: - secretRef: name: {{ include "odoo.fullname" . }}-extra-env ```