### PR TITLE
feat(fast-app): support additional service ports

### DIFF
--- a/charts/fast-app/Chart.yaml
+++ b/charts/fast-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fastapi-app
 description: "Chart genérico e reutilizável para rodar aplicações FastAPI (ex.: kmee-tecnospeed-gateway)"
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "latest"
 keywords:
   - fastapi

--- a/charts/fast-app/ci/ct-values.yaml
+++ b/charts/fast-app/ci/ct-values.yaml
@@ -8,6 +8,11 @@ containerPort: 80
 service:
   port: 80
   targetPort: 80
+  # Exercita o caminho multi-porta contra o API server real do kind, que é quem
+  # valida de fato nome/número de porta duplicado e o limite de 15 caracteres.
+  extraPorts:
+    - name: internal
+      port: 8082
 
 healthCheck:
   enabled: false

--- a/charts/fast-app/templates/deployment.yaml
+++ b/charts/fast-app/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+            {{- range .Values.service.extraPorts }}
+            - name: {{ required "service.extraPorts[].name é obrigatório" .name }}
+              containerPort: {{ .targetPort | default (required "service.extraPorts[].port é obrigatório" .port) }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
           {{- if or .Values.env .Values.secretEnv .Values.envFrom }}
           envFrom:
             {{- if .Values.env }}

--- a/charts/fast-app/templates/service.yaml
+++ b/charts/fast-app/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- range .Values.service.extraPorts }}
+    - name: {{ required "service.extraPorts[].name é obrigatório" .name }}
+      port: {{ required "service.extraPorts[].port é obrigatório" .port }}
+      targetPort: {{ .targetPort | default .port }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}
   selector:
     {{- include "fastapi-app.selectorLabels" . | nindent 4 }}

--- a/charts/fast-app/tests/deployment_test.yaml
+++ b/charts/fast-app/tests/deployment_test.yaml
@@ -39,3 +39,52 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should declare only the http container port by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].ports
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+
+  - it: should derive container ports from service.extraPorts
+    set:
+      service.extraPorts:
+        - name: internal
+          port: 8082
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].ports
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].ports[1]
+          value:
+            name: internal
+            containerPort: 8082
+            protocol: TCP
+
+  - it: should use extraPorts targetPort as the containerPort when set
+    set:
+      service.extraPorts:
+        - name: internal
+          port: 8082
+          targetPort: 9000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9000
+
+  - it: should keep probes on the http port when extraPorts are set
+    set:
+      service.extraPorts:
+        - name: internal
+          port: 8082
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http

--- a/charts/fast-app/tests/httproute_test.yaml
+++ b/charts/fast-app/tests/httproute_test.yaml
@@ -148,3 +148,24 @@ tests:
       - equal:
           path: spec.rules[0].backendRefs[0].port
           value: 8800
+
+  # Guarda de regressão: service.extraPorts NUNCA deve virar rota. Uma porta
+  # interna alcançável pelo gateway cairia no catch-all da app e responderia
+  # HTML com 200 em vez da API interna.
+  - it: should never route service.extraPorts
+    set:
+      ingress.enabled: true
+      ingress.type: "gateway-api"
+      service.extraPorts:
+        - name: internal
+          port: 8082
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 1
+      - lengthEqual:
+          path: spec.rules[0].backendRefs
+          count: 1
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8800

--- a/charts/fast-app/tests/ingress_test.yaml
+++ b/charts/fast-app/tests/ingress_test.yaml
@@ -38,3 +38,20 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: traefik
+
+  # Guarda de regressão: service.extraPorts NUNCA deve virar rota. Uma porta
+  # interna alcançável pelo ingress cairia no catch-all da app e responderia
+  # HTML com 200 em vez da API interna.
+  - it: should never route service.extraPorts
+    set:
+      ingress.enabled: true
+      service.extraPorts:
+        - name: internal
+          port: 8082
+    asserts:
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8800

--- a/charts/fast-app/tests/service_test.yaml
+++ b/charts/fast-app/tests/service_test.yaml
@@ -21,3 +21,60 @@ tests:
       - equal:
           path: spec.type
           value: LoadBalancer
+
+  - it: should expose only the http port by default
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  - it: should append extraPorts after the http port
+    set:
+      service.extraPorts:
+        - name: internal
+          port: 8082
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 2
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: internal
+            port: 8082
+            targetPort: 8082
+            protocol: TCP
+
+  - it: should honour explicit targetPort and protocol on extraPorts
+    set:
+      service.extraPorts:
+        - name: metrics
+          port: 9090
+          targetPort: 9100
+          protocol: UDP
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: metrics
+            port: 9090
+            targetPort: 9100
+            protocol: UDP
+
+  - it: should support multiple extraPorts
+    set:
+      service.extraPorts:
+        - name: internal
+          port: 8082
+        - name: metrics
+          port: 9090
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 3

--- a/charts/fast-app/values.yaml
+++ b/charts/fast-app/values.yaml
@@ -27,6 +27,28 @@ service:
   port: 8800
   # Porta do container para onde o tráfego é encaminhado.
   targetPort: 5057
+  # Portas adicionais expostas no mesmo Service e no mesmo container.
+  # Use quando o processo escuta em mais de uma porta (ex.: uma API interna
+  # service-to-service separada da pública).
+  #
+  # Estas portas NÃO são roteadas pelo ingress/httproute — eles sempre apontam
+  # para `service.port`. Com `service.type: ClusterIP` (default), portanto, só
+  # são alcançáveis pelo DNS interno do cluster:
+  #   http://<service>.<namespace>.svc.cluster.local:<port>
+  #
+  # ATENÇÃO: com `service.type: NodePort` ou `LoadBalancer` estas portas também
+  # são publicadas externamente, como qualquer porta do Service. Se a porta deve
+  # ficar restrita ao cluster, use ClusterIP (e/ou uma NetworkPolicy).
+  #
+  # Cada item aceita:
+  #   name       (obrigatório) nome da porta; máx. 15 caracteres, [a-z0-9-]
+  #   port       (obrigatório) porta exposta pelo Service
+  #   targetPort (opcional)    porta do container, NUMÉRICA (vira containerPort,
+  #                            que não aceita porta nomeada); default = port
+  #   protocol   (opcional)    default = TCP
+  extraPorts: []
+    # - name: internal
+    #   port: 8082
 
 # ------------------------------------------------------------------------------
 # Variáveis de ambiente (substitui o env_file: .env do compose)


### PR DESCRIPTION
Some apps serve more than one port from a single process, e.g. a public API plus a separate service-to-service API. The chart only rendered one Service port and one container port, so those apps could not be deployed.

Add `service.extraPorts`, appended after the primary `http` port on the Service and derived into the container ports so both manifests cannot drift. Each item takes `name` and `port`, optionally `targetPort` (numeric, defaults to `port`) and `protocol` (defaults to TCP).

The routing templates keep pointing at `service.port` alone, so extra ports are never exposed through the Ingress or the HTTPRoute. That is the point of the feature: an internal port reachable from outside would fall through to the app's catch-all and answer HTML instead of the internal API. Regression tests in both routing suites pin the behaviour.

`name` and `port` go through `required` so a typo fails at render time with a precise message rather than rendering a null and failing on apply. Duplicate names, the 15-char limit and the protocol enum are left to the API server, which validates them authoritatively; ct-values.yaml now exercises the multi-port path so CI actually applies it to a cluster.

Defaults are unchanged: with `extraPorts` empty the chart renders exactly as before.